### PR TITLE
Feature/SI-3470 - Re-organize the csp_crc32 module

### DIFF
--- a/include/csp/csp_crc32.h
+++ b/include/csp/csp_crc32.h
@@ -12,6 +12,14 @@ extern "C" {
 #endif
 
 /**
+   CRC32 calculation object (digest object)
+   Create an instance of this object before calling any of the
+   following methods.
+   csp_crc32_init(), csp_crc32_update() or csp_crc32_final()
+ */
+typedef uint32_t csp_crc32_t;
+
+/**
    Append CRC32 checksum to packet
    @param[in] packet CSP packet, must be valid.
    @return #CSP_ERR_NONE on success, otherwise an error code.
@@ -32,6 +40,27 @@ int csp_crc32_verify(csp_packet_t * packet);
    @return checksum
 */
 uint32_t csp_crc32_memory(const uint8_t * addr, uint32_t length);
+
+/**
+   Initialize the CRC32 object prior to calculating checksum.
+   @param[in] crc CRC32 object previously created by the caller
+*/
+void csp_crc32_init(csp_crc32_t *crc);
+
+/**
+   Update the CRC32 calculation with a chunk of data
+   @param[in] crc CRC32 object previously created, and init'ed by the caller
+   @param[in] data pointer to data for which to update checksum on
+   @param[in] length number of bytes in the array pointed to by data
+*/
+void csp_crc32_update(csp_crc32_t * crc, const uint8_t * data, uint32_t length);
+
+/**
+   Finalize the CRC32 checksum calculation.
+   @param[in] crc CRC32 object previously created, init'ed and updated by the caller
+   @return checksum
+*/
+uint32_t csp_crc32_final(csp_crc32_t *crc);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Re-organized the csp_crc32 module to be able to do crc32 checksums in a "streaming" fashion. This eliminates the need for us to have access to the entire data buffer at once, but it can be split up into chunks.

The original interface is not touched, but the inner workings has been reorganized