### PR TITLE
[SI-3931] Server implementations using `csp_send()` have no way of detecting a broken-pipe (connection timeout)

### DIFF
--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -268,6 +268,20 @@ int csp_conn_src(csp_conn_t *conn);
 int csp_conn_flags(csp_conn_t *conn);
 
 /**
+ * Return if the CSP connection is active
+ * 
+ * Active in this context means if the protocol layers is connected and no time outs has happened.
+ * Especially if a connection is marked as a RDP connection, the active state means that the
+ * RDP layers are connected and no time outs have happened. If the RDP layer has a connection timeout
+ * or of the connection is closing, the connection is inactive, and ready to be closed.
+ * 
+ * @param conn connection
+ * @return true if the connection is active
+ * @return false if the connection is in-active
+ */
+bool csp_conn_is_active(csp_conn_t *conn);
+
+/**
  * Set socket to listen for incoming connections.
  *
  * @param[in] socket socket

--- a/src/csp_conn.c
+++ b/src/csp_conn.c
@@ -406,3 +406,15 @@ const csp_conn_t * csp_conn_get_array(size_t * size) {
         *size = CSP_CONN_MAX;
         return arr_conn;
 }
+
+bool csp_conn_is_active(csp_conn_t *conn) {
+#if (CSP_USE_RDP)
+	if ((conn->idin.flags & CSP_FRDP) || (conn->idout.flags & CSP_FRDP)) {
+		/* This is for sure an RDP connection */
+		return csp_rdp_conn_is_active(conn);
+	}
+#endif
+
+	/* Non RDP connections are always "active" */
+	return true;
+}

--- a/src/csp_rdp.h
+++ b/src/csp_rdp.h
@@ -10,5 +10,6 @@ int csp_rdp_connect(csp_conn_t * conn);
 int csp_rdp_close(csp_conn_t * conn, uint8_t closed_by);
 int csp_rdp_send(csp_conn_t * conn, csp_packet_t * packet);
 int csp_rdp_check_ack(csp_conn_t * conn);
+bool csp_rdp_conn_is_active(csp_conn_t *conn);
 
 void csp_rdp_conn_print(csp_conn_t * conn);

--- a/src/csp_sfp.c
+++ b/src/csp_sfp.c
@@ -54,7 +54,7 @@ int csp_sfp_send_own_memcpy(csp_conn_t * conn, const void * data, unsigned int t
 	}
 
 	unsigned int count = 0;
-	while (count < totalsize) {
+	while ((count < totalsize) && csp_conn_is_active(conn)) {
 
 		sfp_header_t * sfp_header;
 


### PR DESCRIPTION
The RDP implementation did not take connection timeouts into account, when the connection is in the OPEN state. This could result in servers sending data onto a RDP connection would not be able to detect if the client was lost.

This PR includes an attempt at fixing that issue by implementing a new API in csp.h called `csp_conn_is_active()` which returns the state of a particular connection object. The connection time out is monitored in the RDP layer by time stamping the connection on the reception of each packet in OPEN state.

The SFP implemention in the CSP library has been made to use this new API to be able to bail the TX loop if the connection is no longer active.