### PR TITLE
Accept a void pointer as input to CRC calculator

### DIFF
--- a/include/csp/csp_crc32.h
+++ b/include/csp/csp_crc32.h
@@ -42,7 +42,7 @@ int csp_crc32_verify(csp_packet_t * packet);
  * @param[in] length length of memory to do checksum on
  * @return checksum
  */
-uint32_t csp_crc32_memory(const uint8_t * addr, uint32_t length);
+uint32_t csp_crc32_memory(const void * addr, uint32_t length);
 
 /**
    Initialize the CRC32 object prior to calculating checksum.
@@ -56,7 +56,7 @@ void csp_crc32_init(csp_crc32_t *crc);
    @param[in] data pointer to data for which to update checksum on
    @param[in] length number of bytes in the array pointed to by data
 */
-void csp_crc32_update(csp_crc32_t * crc, const uint8_t * data, uint32_t length);
+void csp_crc32_update(csp_crc32_t * crc, const void * data, uint32_t length);
 
 /**
    Finalize the CRC32 checksum calculation.

--- a/src/csp_crc32.c
+++ b/src/csp_crc32.c
@@ -51,14 +51,16 @@ void csp_crc32_init(csp_crc32_t * crc) {
 	}
 }
 
-void csp_crc32_update(csp_crc32_t * crc, const uint8_t * data, uint32_t length) {
+void csp_crc32_update(csp_crc32_t * crc, const void * data, uint32_t length) {
+
+	const uint8_t * data8 = (uint8_t*)data;
 
 	if (crc) {
 		while (length--) {
 #ifdef __AVR__
-			crc = pgm_read_dword(&crc_tab[(crc ^ *data++) & 0xFFL]) ^ (crc >> 8);
+			crc = pgm_read_dword(&crc_tab[(crc ^ *data8++) & 0xFFL]) ^ (crc >> 8);
 #else
-			(*crc) = crc_tab[((*crc) ^ *data++) & 0xFFL] ^ ((*crc) >> 8);
+			(*crc) = crc_tab[((*crc) ^ *data8++) & 0xFFL] ^ ((*crc) >> 8);
 #endif
 		}
 	}
@@ -73,7 +75,7 @@ uint32_t csp_crc32_final(csp_crc32_t *crc) {
 	return 0;
 }
 
-uint32_t csp_crc32_memory(const uint8_t * data, uint32_t length) {
+uint32_t csp_crc32_memory(const void * data, uint32_t length) {
 
 	csp_crc32_t crc;
 


### PR DESCRIPTION
Jeg er ikke sikker på, om det har nogle ulemper, men hvis funktionerne tager en void pointer, slipper vi ofte for typecasts når man skal bruge dem.