### PR TITLE
Feature/si 4694

### DIFF
--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -481,9 +481,11 @@ void csp_rdp_get_opt(unsigned int *window_size, unsigned int *conn_timeout_ms,
 	  unsigned int *ack_timeout, unsigned int *ack_delay_count);
 
 /**
- * Set platform specific memory copy function.
+ * Set platform specific memory copy functions.
  */
 void csp_cmp_set_memcpy(csp_memcpy_fnc_t fnc);
+void csp_cmp_set_memread64(csp_memread64_fnc_t fnc);
+void csp_cmp_set_memwrite64(csp_memwrite64_fnc_t fnc);
 
 #if (CSP_ENABLE_CSP_PRINT)
 

--- a/include/csp/csp_cmp.h
+++ b/include/csp/csp_cmp.h
@@ -62,6 +62,14 @@ extern "C" {
  *  Set/configure routing.
  */
 #define CSP_CMP_ROUTE_SET_V2 7
+/**
+ *  Peek/read data from memory - 64-bit version.
+ */
+#define CSP_CMP_PEEK_V2 8
+/**
+ *  Poke/write data from memory - 64-bit version.
+ */
+#define CSP_CMP_POKE_V2 9
 /**@}*/
 
 /**
@@ -91,6 +99,16 @@ extern "C" {
  *  CMP poke/write memeory - max write length.
  */
 #define CSP_CMP_POKE_MAX_LEN 200
+
+/**
+ *  CMP peek/read memory - max read length - 64-bit.
+ */
+#define CSP_CMP_PEEK_V2_MAX_LEN 196
+
+/**
+ *  CMP poke/write memory - max write length - 64-bit.
+ */
+#define CSP_CMP_POKE_V2_MAX_LEN 196
 
 /**
  *  CSP management protocol description.
@@ -142,6 +160,16 @@ struct csp_cmp_message {
 			uint8_t len;
 			char data[CSP_CMP_POKE_MAX_LEN];
 		} poke;
+		struct {
+			uint64_t vaddr;
+			uint8_t len;
+			char data[CSP_CMP_PEEK_V2_MAX_LEN];
+		} peek_v2;
+		struct {
+			uint64_t vaddr;
+			uint8_t len;
+			char data[CSP_CMP_POKE_V2_MAX_LEN];
+		} poke_v2;
 		csp_timestamp_t clock;
 	};
 } __attribute__((__packed__));
@@ -199,6 +227,30 @@ static inline int csp_cmp_peek(uint16_t node, uint32_t timeout, struct csp_cmp_m
  */
 static inline int csp_cmp_poke(uint16_t node, uint32_t timeout, struct csp_cmp_message *msg) {
 	return csp_cmp(node, timeout, CSP_CMP_POKE, CMP_SIZE(poke) - sizeof(msg->poke.data) + msg->poke.len, msg);
+}
+
+/**
+ * Peek (read) memory on remote node - 64-bit version.
+ *
+ *	@param[in] node address of subsystem.
+ *	@param[in] timeout timeout in mS to wait for reply..
+ *	@param[in/out] msg memory address and number of bytes to peek. (msg peeked/read memory)
+ *	@return #CSP_ERR_NONE on success, otherwise an error code.
+ */
+static inline int csp_cmp_peek_v2(uint16_t node, uint32_t timeout, struct csp_cmp_message *msg) {
+	return csp_cmp(node, timeout, CSP_CMP_PEEK_V2, CMP_SIZE(peek_v2) - sizeof(msg->peek_v2.data) + msg->peek_v2.len, msg);
+}
+
+/**
+ * Poke (write) memory on remote node - 64-bit version.
+ *
+ *	@param[in] node address of subsystem.
+ *	@param[in] timeout timeout in mS to wait for reply..
+ *	@param[in] msg memory address, number of bytes and the actual bytes to poke/write.
+ *	@return #CSP_ERR_NONE on success, otherwise an error code.
+ */
+static inline int csp_cmp_poke_v2(uint16_t node, uint32_t timeout, struct csp_cmp_message *msg) {
+	return csp_cmp(node, timeout, CSP_CMP_POKE_V2, CMP_SIZE(poke_v2) - sizeof(msg->poke_v2.data) + msg->poke_v2.len, msg);
 }
 
 #ifdef __cplusplus

--- a/include/csp/csp_cmp.h
+++ b/include/csp/csp_cmp.h
@@ -161,12 +161,12 @@ struct csp_cmp_message {
 			char data[CSP_CMP_POKE_MAX_LEN];
 		} poke;
 		struct {
-			uint64_t vaddr;
+			uint64_t vaddr; /* Virtual 64-bit address on the target system */
 			uint8_t len;
 			char data[CSP_CMP_PEEK_V2_MAX_LEN];
 		} peek_v2;
 		struct {
-			uint64_t vaddr;
+			uint64_t vaddr; /* Virtual 64-bit address on the target system */
 			uint8_t len;
 			char data[CSP_CMP_POKE_V2_MAX_LEN];
 		} poke_v2;

--- a/include/csp/csp_types.h
+++ b/include/csp/csp_types.h
@@ -205,12 +205,15 @@ typedef const uint32_t csp_const_memptr_t;
 typedef void * csp_memptr_t;
 /** Const memory pointer */
 typedef const void * csp_const_memptr_t;
+/** Memory pointer 64-bit */
+typedef uint64_t csp_memptr64_t;
 #endif
 
 /**
  * Platform specific memory copy function.
  */
 typedef csp_memptr_t (*csp_memcpy_fnc_t)(csp_memptr_t, csp_const_memptr_t, size_t);
+typedef csp_memptr64_t (*csp_memcpy64_fnc_t)(csp_memptr64_t, csp_memptr64_t, size_t);
 
 /**
  * Compile check/asserts.

--- a/include/csp/csp_types.h
+++ b/include/csp/csp_types.h
@@ -213,7 +213,8 @@ typedef uint64_t csp_memptr64_t;
  * Platform specific memory copy function.
  */
 typedef csp_memptr_t (*csp_memcpy_fnc_t)(csp_memptr_t, csp_const_memptr_t, size_t);
-typedef csp_memptr64_t (*csp_memcpy64_fnc_t)(csp_memptr64_t, csp_memptr64_t, size_t);
+typedef csp_memptr64_t (*csp_memread64_fnc_t)(csp_const_memptr_t, csp_memptr64_t, size_t);
+typedef csp_memptr64_t (*csp_memwrite64_fnc_t)(csp_memptr64_t, csp_memptr_t, size_t);
 
 /**
  * Compile check/asserts.

--- a/src/csp_service_handler.c
+++ b/src/csp_service_handler.c
@@ -144,6 +144,10 @@ static int do_cmp_peek_v2(struct csp_cmp_message * cmp) {
 	if (cmp->peek_v2.len > CSP_CMP_PEEK_MAX_LEN)
 		return CSP_ERR_INVAL;
 
+	if (!csp_cmp_memread64_fnc) {
+		return CSP_ERR_DRIVER;
+	}
+
 	/* Dangerous, you better know what you are doing */
 	csp_cmp_memread64_fnc(cmp->peek_v2.data, cmp->peek_v2.vaddr, cmp->peek_v2.len);
 
@@ -155,6 +159,10 @@ static int do_cmp_poke_v2(struct csp_cmp_message * cmp) {
 	cmp->poke_v2.vaddr = htobe64(cmp->poke_v2.vaddr);
 	if (cmp->poke_v2.len > CSP_CMP_POKE_MAX_LEN)
 		return CSP_ERR_INVAL;
+
+	if (!csp_cmp_memwrite64_fnc) {
+		return CSP_ERR_DRIVER;
+	}
 
 	/* Extremely dangerous, you better know what you are doing */
 	csp_cmp_memwrite64_fnc(cmp->poke_v2.vaddr, cmp->poke_v2.data, cmp->poke_v2.len);

--- a/src/csp_service_handler.c
+++ b/src/csp_service_handler.c
@@ -22,12 +22,20 @@ static uint32_t wrap_32bit_memcpy(uint32_t to, const uint32_t from, size_t size)
 static csp_memcpy_fnc_t csp_cmp_memcpy_fnc = wrap_32bit_memcpy;
 #else
 static csp_memcpy_fnc_t csp_cmp_memcpy_fnc = (csp_memcpy_fnc_t)memcpy;
-static csp_memcpy64_fnc_t csp_cmp_memcpy64_fnc = (csp_memcpy64_fnc_t)NULL;
+static csp_memread64_fnc_t csp_cmp_memread64_fnc = (csp_memread64_fnc_t)NULL;
+static csp_memwrite64_fnc_t csp_cmp_memwrite64_fnc = (csp_memwrite64_fnc_t)NULL;
 #endif
 
 void csp_cmp_set_memcpy(csp_memcpy_fnc_t fnc) {
 	csp_cmp_memcpy_fnc = fnc;
-	csp_cmp_memcpy64_fnc = (csp_memcpy64_fnc_t)(void *)fnc;
+}
+
+void csp_cmp_set_memread64(csp_memread64_fnc_t fnc) {
+	csp_cmp_memread64_fnc = fnc;
+}
+
+void csp_cmp_set_memwrite64(csp_memwrite64_fnc_t fnc) {
+	csp_cmp_memwrite64_fnc = fnc;
 }
 
 static int do_cmp_ident(struct csp_cmp_message * cmp) {
@@ -137,7 +145,7 @@ static int do_cmp_peek_v2(struct csp_cmp_message * cmp) {
 		return CSP_ERR_INVAL;
 
 	/* Dangerous, you better know what you are doing */
-	csp_cmp_memcpy64_fnc((csp_memptr64_t)(uintptr_t)cmp->peek_v2.data, cmp->peek_v2.vaddr, cmp->peek_v2.len);
+	csp_cmp_memread64_fnc(cmp->peek_v2.data, cmp->peek_v2.vaddr, cmp->peek_v2.len);
 
 	return CSP_ERR_NONE;
 }
@@ -149,7 +157,7 @@ static int do_cmp_poke_v2(struct csp_cmp_message * cmp) {
 		return CSP_ERR_INVAL;
 
 	/* Extremely dangerous, you better know what you are doing */
-	csp_cmp_memcpy64_fnc(cmp->poke_v2.vaddr, (csp_memptr64_t)(uintptr_t)cmp->poke_v2.data, cmp->poke_v2.len);
+	csp_cmp_memwrite64_fnc(cmp->poke_v2.vaddr, cmp->poke_v2.data, cmp->poke_v2.len);
 
 	return CSP_ERR_NONE;
 }


### PR DESCRIPTION
Extended the CSP CMP module with version 2 (64-bit) of the peek and poke commands. These require a 64-bit addressing API for reading and writing memory to the "host-system". This will be hooked up to vmem, which is now 64-bit addresses.