### PR TITLE
Fix Build Without Assert

### DIFF
--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -2,6 +2,11 @@
 
 #if (CSP_HAVE_LIBZMQ)
 
+/* csp_zmqhub_init_w_name_endpoints_rxfilter() and csp_zmqhub_init_filter2() cannot build without asserts,
+	as that triggers -Werror=unused-but-set-variable for the 'int ret;' variable.
+	We fix this by building with assert anyway, as we don't have any other error handling. */
+#undef NDEBUG
+
 #include <zmq.h>
 #include <assert.h>
 #include <stdlib.h>


### PR DESCRIPTION
Currently [csp_if_zmqhub.c](https://github.com/spaceinventor/libcsp/blob/bb8110ce9b297c879e7805684514b32908bfa712/src/interfaces/csp_if_zmqhub.c#L165) will fail to build without assert, due to the presence of "unused" 'int ret;' variables.

This PR proposes to fix this compile error by always building this file with assert, at least until we properly handle the returned error.
