### PR TITLE
Remove unnecessary clone of a few bytes in csp_buffer_clone

### DIFF
--- a/src/csp_buffer.c
+++ b/src/csp_buffer.c
@@ -139,7 +139,7 @@ void * csp_buffer_clone(void * buffer) {
 
 	csp_packet_t * clone = csp_buffer_get(packet->length);
 	if (clone) {
-		size_t size = sizeof(csp_packet_t) - CSP_BUFFER_SIZE + CSP_PACKET_PADDING_BYTES + packet->length;
+		size_t size = sizeof(csp_packet_t) - CSP_BUFFER_SIZE + packet->length;
 		memcpy(clone, packet, size > sizeof(csp_packet_t) ? sizeof(csp_packet_t) : size);
 	}
 


### PR DESCRIPTION
csp_buffer_clone is unnecessarily adding CSP_PACKET_PADDING_BYTES to the
calculation of number of required bytes to memcpy. These bytes should already
be accounted for by the sizeof(csp_packet_t). While there is no danger in doing
this, as the memcpy gates the size of the copy to sizeof(csp_packet_t), it does
cause an excess copy of a few bytes per call.