### PR TITLE
check timeout even if userspace

### DIFF
--- a/src/csp_rdp.c
+++ b/src/csp_rdp.c
@@ -409,6 +409,12 @@ void csp_rdp_check_timeouts(csp_conn_t * conn) {
 
 	if (conn->rdp.state == RDP_OPEN) {
 
+		if (csp_rdp_time_after(time_now, conn->timestamp + conn->rdp.conn_timeout)) {
+			csp_conn_close(conn, CSP_RDP_CLOSED_BY_PROTOCOL | CSP_RDP_CLOSED_BY_TIMEOUT);
+			csp_bin_sem_post(&conn->rdp.tx_wait);
+			return;
+		}
+
 		/* Check if we have unacknowledged segments */
 		if (conn->rdp.delayed_acks) {
 			csp_rdp_check_ack(conn);


### PR DESCRIPTION
After [this commit](https://github.com/spaceinventor/libcsp/commit/82648177d52caaeffa723c645fe14e798325095e) we wait for tx window space or connection timeout. 
If we lose connection we will get stuck indefinitely, waiting for tx window.

https://github.com/spaceinventor/libcsp/blob/cb3f265e7c89bd82a014b27ccc097fb6e63befea/src/csp_rdp.c#L803-L820

Because we block the userspace with csp_send they can't use https://github.com/spaceinventor/libcsp/blob/cb3f265e7c89bd82a014b27ccc097fb6e63befea/src/csp_rdp.c#L946

I assume we do not want to do the connection check inside csp_rdp_send?