### PR TITLE
Post init promisc config

### DIFF
--- a/include/csp/interfaces/csp_if_zmqhub.h
+++ b/include/csp/interfaces/csp_if_zmqhub.h
@@ -123,6 +123,10 @@ int csp_zmqhub_init_w_name_endpoints_rxfilter(const char * ifname, uint16_t addr
 int csp_zmqhub_init_filter2(const char * ifname, const char * host, uint16_t addr, uint16_t netmask, int promisc, csp_iface_t ** return_interface, char * sec_key, uint16_t subport, uint16_t pubport);
 
 
+void csp_zmqhub_remove_filters(csp_iface_t * zmq_iface);
+void csp_zmqhub_add_filters(csp_iface_t * zmq_iface);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -242,6 +242,7 @@ void csp_zmqhub_remove_filters(csp_iface_t * zmq_iface) {
 	/* subscribe to all packets - no filter */
 	ret = zmq_setsockopt(drv->subscriber, ZMQ_SUBSCRIBE, NULL, 0);
 	assert(ret == 0);
+	(void)ret;
 }
 
 void csp_zmqhub_add_filters(csp_iface_t * zmq_iface) {
@@ -266,6 +267,7 @@ void csp_zmqhub_add_filters(csp_iface_t * zmq_iface) {
 		ret = zmq_setsockopt(drv->subscriber, ZMQ_SUBSCRIBE, &drv->filt[i][2], 2);
 	}
 	assert(ret == 0);
+	(void)ret;
 }
 
 int csp_zmqhub_init_filter2(const char * ifname, const char * host, uint16_t addr, uint16_t netmask, int promisc, csp_iface_t ** return_interface, char * sec_key, uint16_t subport, uint16_t pubport) {

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -18,6 +18,9 @@ typedef struct {
 	void * context;
 	void * publisher;
 	void * subscriber;
+	/* We must allocate filters per interface, as ZMQ does not copy the filter value to the
+		outgoing packet for each setsockopt call. */
+	uint16_t filt[4][3];
 	char name[CSP_IFLIST_NAME_MAX + 1];
 	csp_iface_t iface;
 } zmq_driver_t;
@@ -218,6 +221,53 @@ int csp_zmqhub_init_w_name_endpoints_rxfilter(const char * ifname, uint16_t addr
 	return CSP_ERR_NONE;
 }
 
+void csp_zmqhub_remove_filters(csp_iface_t * zmq_iface) {
+
+	int ret = 0;
+	zmq_driver_t * drv = zmq_iface->driver_data;
+	const uint16_t addr = zmq_iface->addr;
+	const uint16_t hostmask = (1 << (csp_id_get_host_bits() - zmq_iface->netmask)) - 1;
+
+	/* Unsubscribe from any current filters */
+	for (int i = 0; i < 4; i++) {
+		//int i = CSP_PRIO_NORM;
+		drv->filt[i][0] = __builtin_bswap16((i << 14) | addr);
+		drv->filt[i][1] = __builtin_bswap16((i << 14) | addr | hostmask);
+		drv->filt[i][2] = __builtin_bswap16((i << 14) | 16383);
+		ret = zmq_setsockopt(drv->subscriber, ZMQ_UNSUBSCRIBE, &drv->filt[i][0], 2);
+		ret = zmq_setsockopt(drv->subscriber, ZMQ_UNSUBSCRIBE, &drv->filt[i][1], 2);
+		ret = zmq_setsockopt(drv->subscriber, ZMQ_UNSUBSCRIBE, &drv->filt[i][2], 2);
+	}
+
+	/* subscribe to all packets - no filter */
+	ret = zmq_setsockopt(drv->subscriber, ZMQ_SUBSCRIBE, NULL, 0);
+	assert(ret == 0);
+}
+
+void csp_zmqhub_add_filters(csp_iface_t * zmq_iface) {
+
+	int ret = 0;
+	zmq_driver_t * drv = zmq_iface->driver_data;
+	const uint16_t addr = zmq_iface->addr;
+	const uint16_t hostmask = (1 << (csp_id_get_host_bits() - zmq_iface->netmask)) - 1;
+
+	/* Subscribe to all packets - no filter */
+	ret = zmq_setsockopt(drv->subscriber, ZMQ_UNSUBSCRIBE, NULL, 0);
+	assert(ret == 0);
+
+	/* Subscribe to unpromiscuous filters */
+	for (int i = 0; i < 4; i++) {
+		//int i = CSP_PRIO_NORM;
+		drv->filt[i][0] = __builtin_bswap16((i << 14) | addr);
+		drv->filt[i][1] = __builtin_bswap16((i << 14) | addr | hostmask);
+		drv->filt[i][2] = __builtin_bswap16((i << 14) | 16383);
+		ret = zmq_setsockopt(drv->subscriber, ZMQ_SUBSCRIBE, &drv->filt[i][0], 2);
+		ret = zmq_setsockopt(drv->subscriber, ZMQ_SUBSCRIBE, &drv->filt[i][1], 2);
+		ret = zmq_setsockopt(drv->subscriber, ZMQ_SUBSCRIBE, &drv->filt[i][2], 2);
+	}
+	assert(ret == 0);
+}
+
 int csp_zmqhub_init_filter2(const char * ifname, const char * host, uint16_t addr, uint16_t netmask, int promisc, csp_iface_t ** return_interface, char * sec_key, uint16_t subport, uint16_t pubport) {
 	
 	/* ZMQ will cause valgrind errors if `sec_key` isn't exactly 40 characters long.
@@ -248,6 +298,9 @@ int csp_zmqhub_init_filter2(const char * ifname, const char * host, uint16_t add
 	drv->iface.name = drv->name;
 	drv->iface.driver_data = drv;
 	drv->iface.nexthop = csp_zmqhub_tx;
+
+	drv->iface.addr = addr;
+	drv->iface.netmask = netmask;
 
 	drv->context = zmq_ctx_new();
 	assert(drv->context != NULL);
@@ -293,9 +346,6 @@ int csp_zmqhub_init_filter2(const char * ifname, const char * host, uint16_t add
 	zmq_setsockopt(drv->subscriber, ZMQ_TCP_KEEPALIVE_IDLE, &idle, sizeof(idle));
 	zmq_setsockopt(drv->subscriber, ZMQ_TCP_KEEPALIVE_CNT, &cnt, sizeof(cnt));
 	zmq_setsockopt(drv->subscriber, ZMQ_TCP_KEEPALIVE_INTVL, &intvl, sizeof(intvl));
-
-	/* Generate filters */
-	uint16_t hostmask = (1 << (csp_id_get_host_bits() - netmask)) - 1;
 	
 	/* Connect to server */
 	ret = zmq_connect(drv->publisher, pub);
@@ -305,28 +355,12 @@ int csp_zmqhub_init_filter2(const char * ifname, const char * host, uint16_t add
 	(void)ret;
 
 	if (promisc) {
-
 		// subscribe to all packets - no filter
-		ret = zmq_setsockopt(drv->subscriber, ZMQ_SUBSCRIBE, NULL, 0);
-		assert(ret == 0);
+		csp_zmqhub_remove_filters(&drv->iface);
 
 	} else {
-
-		/* This needs to be static, because ZMQ does not copy the filter value to the
-		 * outgoing packet for each setsockopt call */
-		static uint16_t filt[4][3];
-
-		for (int i = 0; i < 4; i++) {
-			//int i = CSP_PRIO_NORM;
-			filt[i][0] = __builtin_bswap16((i << 14) | addr);
-			filt[i][1] = __builtin_bswap16((i << 14) | addr | hostmask);
-			filt[i][2] = __builtin_bswap16((i << 14) | 16383);
-			ret = zmq_setsockopt(drv->subscriber, ZMQ_SUBSCRIBE, &filt[i][0], 2);
-			ret = zmq_setsockopt(drv->subscriber, ZMQ_SUBSCRIBE, &filt[i][1], 2);
-			ret = zmq_setsockopt(drv->subscriber, ZMQ_SUBSCRIBE, &filt[i][2], 2);
-		}
-
-	} 
+		csp_zmqhub_add_filters(&drv->iface);
+	}
 
 
 	/* Start RX thread */


### PR DESCRIPTION
Added `csp_zmqhub_<add/remove>_filters() ` to change promisc settings after init.

Tested with Valgrind without warnings or errors. I didn't add a mutex, as it didn't appear to be necessary.

This is currently used by the following PyCSH commit: https://github.com/spaceinventor/PyCSH/commit/0e398e41969cb7f7f712b8a4999252ba20d46fa8#diff-a1457fd5997277b0ab808d1e18fdd8b8d874b88ead8ebd1b33ee4e6e4ff8fdb9
Which is implemented in pycsh_core here: https://github.com/spaceinventor/pycsh_core/commit/c07939ace617d0b933c29732f66dcd856f7c2b1b#diff-b8f67f3336f931c16d8f7da067ee582289b8a735040cb5a4fbc2735deaf72e96R228

I got tired of having to close CSH because someone added promisc to my interfaces :)
