### PR TITLE
Feature/enable-standard-install

### DIFF
--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -481,9 +481,11 @@ void csp_rdp_get_opt(unsigned int *window_size, unsigned int *conn_timeout_ms,
 	  unsigned int *ack_timeout, unsigned int *ack_delay_count);
 
 /**
- * Set platform specific memory copy function.
+ * Set platform specific memory copy functions.
  */
 void csp_cmp_set_memcpy(csp_memcpy_fnc_t fnc);
+void csp_cmp_set_memread64(csp_memread64_fnc_t fnc);
+void csp_cmp_set_memwrite64(csp_memwrite64_fnc_t fnc);
 
 #if (CSP_ENABLE_CSP_PRINT)
 

--- a/include/csp/csp_cmp.h
+++ b/include/csp/csp_cmp.h
@@ -62,6 +62,14 @@ extern "C" {
  *  Set/configure routing.
  */
 #define CSP_CMP_ROUTE_SET_V2 7
+/**
+ *  Peek/read data from memory - 64-bit version.
+ */
+#define CSP_CMP_PEEK_V2 8
+/**
+ *  Poke/write data from memory - 64-bit version.
+ */
+#define CSP_CMP_POKE_V2 9
 /**@}*/
 
 /**
@@ -91,6 +99,16 @@ extern "C" {
  *  CMP poke/write memeory - max write length.
  */
 #define CSP_CMP_POKE_MAX_LEN 200
+
+/**
+ *  CMP peek/read memory - max read length - 64-bit.
+ */
+#define CSP_CMP_PEEK_V2_MAX_LEN 196
+
+/**
+ *  CMP poke/write memory - max write length - 64-bit.
+ */
+#define CSP_CMP_POKE_V2_MAX_LEN 196
 
 /**
  *  CSP management protocol description.
@@ -142,6 +160,16 @@ struct csp_cmp_message {
 			uint8_t len;
 			char data[CSP_CMP_POKE_MAX_LEN];
 		} poke;
+		struct {
+			uint64_t vaddr; /* Virtual 64-bit address on the target system */
+			uint8_t len;
+			char data[CSP_CMP_PEEK_V2_MAX_LEN];
+		} peek_v2;
+		struct {
+			uint64_t vaddr; /* Virtual 64-bit address on the target system */
+			uint8_t len;
+			char data[CSP_CMP_POKE_V2_MAX_LEN];
+		} poke_v2;
 		csp_timestamp_t clock;
 	};
 } __attribute__((__packed__));
@@ -199,6 +227,30 @@ static inline int csp_cmp_peek(uint16_t node, uint32_t timeout, struct csp_cmp_m
  */
 static inline int csp_cmp_poke(uint16_t node, uint32_t timeout, struct csp_cmp_message *msg) {
 	return csp_cmp(node, timeout, CSP_CMP_POKE, CMP_SIZE(poke) - sizeof(msg->poke.data) + msg->poke.len, msg);
+}
+
+/**
+ * Peek (read) memory on remote node - 64-bit version.
+ *
+ *	@param[in] node address of subsystem.
+ *	@param[in] timeout timeout in mS to wait for reply..
+ *	@param[in/out] msg memory address and number of bytes to peek. (msg peeked/read memory)
+ *	@return #CSP_ERR_NONE on success, otherwise an error code.
+ */
+static inline int csp_cmp_peek_v2(uint16_t node, uint32_t timeout, struct csp_cmp_message *msg) {
+	return csp_cmp(node, timeout, CSP_CMP_PEEK_V2, CMP_SIZE(peek_v2) - sizeof(msg->peek_v2.data) + msg->peek_v2.len, msg);
+}
+
+/**
+ * Poke (write) memory on remote node - 64-bit version.
+ *
+ *	@param[in] node address of subsystem.
+ *	@param[in] timeout timeout in mS to wait for reply..
+ *	@param[in] msg memory address, number of bytes and the actual bytes to poke/write.
+ *	@return #CSP_ERR_NONE on success, otherwise an error code.
+ */
+static inline int csp_cmp_poke_v2(uint16_t node, uint32_t timeout, struct csp_cmp_message *msg) {
+	return csp_cmp(node, timeout, CSP_CMP_POKE_V2, CMP_SIZE(poke_v2) - sizeof(msg->poke_v2.data) + msg->poke_v2.len, msg);
 }
 
 #ifdef __cplusplus

--- a/include/csp/csp_iflist.h
+++ b/include/csp/csp_iflist.h
@@ -35,6 +35,9 @@ int csp_iflist_is_within_subnet(uint16_t addr, csp_iface_t * ifc);
 
 csp_iface_t * csp_iflist_get(void);
 
+int csp_addr_is_alias(uint16_t addr);
+int csp_alias_add(csp_alias_t * addr);
+
 /**
  * Convert bytes to readable string
  */

--- a/include/csp/csp_iflist.h
+++ b/include/csp/csp_iflist.h
@@ -27,6 +27,7 @@ void csp_iflist_remove(csp_iface_t * ifc);
 
 csp_iface_t * csp_iflist_get_by_name(const char * name);
 csp_iface_t * csp_iflist_get_by_addr(uint16_t addr);
+csp_iface_t * csp_iflist_get_by_broadcast(uint16_t addr);
 csp_iface_t * csp_iflist_get_by_subnet(uint16_t addr, csp_iface_t * from);
 csp_iface_t * csp_iflist_get_by_isdfl(csp_iface_t * ifc);
 csp_iface_t * csp_iflist_get_by_index(int idx);

--- a/include/csp/csp_interface.h
+++ b/include/csp/csp_interface.h
@@ -19,6 +19,7 @@ extern "C" {
  * @return #CSP_ERR_NONE on success, otherwise an error code.
  */
 typedef int (*nexthop_t)(csp_iface_t * iface, uint16_t via, csp_packet_t * packet, int from_me);
+typedef int (*csp_alias_add_t)(void * driver_data, uint16_t addr);
 
 /**
  * This struct is referenced in documentation.
@@ -33,6 +34,7 @@ struct csp_iface_s {
 	void * interface_data;      /**< Interface data, only known/used by the interface layer, e.g. state information. */
 	void * driver_data;         /**< Driver data, only known/used by the driver layer, e.g. device/channel references. */
 	nexthop_t nexthop;          /**< Next hop (Tx) function */
+	csp_alias_add_t add_alias;  /**< Add receive address to interface (could be multicast receptions) */
 	uint8_t is_default;         /**< Set default IF flag (CSP supports multiple defaults) */
 
 	/* Stats */
@@ -51,6 +53,18 @@ struct csp_iface_s {
 	struct csp_iface_s * next;
 
 };
+
+/**
+ * Used to represent an alias reception address, bound to a particular interface
+ */
+typedef struct csp_alias_s {
+	uint16_t addr;
+	csp_iface_t * iface;
+
+	/* For linked lists*/
+	struct csp_alias_s * next;
+
+} csp_alias_t;
 
 /**
  * Inputs a new packet into the system.

--- a/include/csp/csp_types.h
+++ b/include/csp/csp_types.h
@@ -204,12 +204,16 @@ typedef const uint32_t csp_const_memptr_t;
 typedef void * csp_memptr_t;
 /** Const memory pointer */
 typedef const void * csp_const_memptr_t;
+/** Memory pointer 64-bit */
+typedef uint64_t csp_memptr64_t;
 #endif
 
 /**
  * Platform specific memory copy function.
  */
 typedef csp_memptr_t (*csp_memcpy_fnc_t)(csp_memptr_t, csp_const_memptr_t, size_t);
+typedef csp_memptr64_t (*csp_memread64_fnc_t)(csp_const_memptr_t, csp_memptr64_t, size_t);
+typedef csp_memptr64_t (*csp_memwrite64_fnc_t)(csp_memptr64_t, csp_memptr_t, size_t);
 
 /**
  * Compile check/asserts.

--- a/include/csp/interfaces/csp_if_zmqhub.h
+++ b/include/csp/interfaces/csp_if_zmqhub.h
@@ -123,7 +123,18 @@ int csp_zmqhub_init_w_name_endpoints_rxfilter(const char * ifname, uint16_t addr
 int csp_zmqhub_init_filter2(const char * ifname, const char * host, uint16_t addr, uint16_t netmask, int promisc, csp_iface_t ** return_interface, char * sec_key, uint16_t subport, uint16_t pubport);
 
 
+/**
+ * Make `zmq_iface` promiscuous (parse all packets)
+ *
+ * Safe to call after `csp_zmqhub_init_filter2()` to change promiscuity.
+ */
 void csp_zmqhub_remove_filters(csp_iface_t * zmq_iface);
+
+/**
+ * Make `zmq_iface` unpromiscuous, only parse matching unicast and broadcast addresses.
+ *
+ * Safe to call after `csp_zmqhub_init_filter2()` to change promiscuity.
+ */
 void csp_zmqhub_add_filters(csp_iface_t * zmq_iface);
 
 

--- a/include/csp/interfaces/csp_if_zmqhub.h
+++ b/include/csp/interfaces/csp_if_zmqhub.h
@@ -123,6 +123,10 @@ int csp_zmqhub_init_w_name_endpoints_rxfilter(const char * ifname, uint16_t addr
 int csp_zmqhub_init_filter2(const char * ifname, const char * host, uint16_t addr, uint16_t netmask, int promisc, csp_iface_t ** return_interface, char * sec_key, uint16_t subport, uint16_t pubport);
 
 
+void csp_zmqhub_remove_filters(csp_iface_t * zmq_iface);
+void csp_zmqhub_add_filters(csp_iface_t * zmq_iface);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/csp/meson.build
+++ b/include/csp/meson.build
@@ -1,1 +1,1 @@
-csp_config_h = configure_file(output: 'autoconfig.h', configuration: conf, install_dir: 'include/csp/')
+csp_config_h = configure_file(output: 'autoconfig.h', configuration: conf, install_dir: 'include/csp/', install_tag: 'devel')

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,4 @@
 project('csp', 'c', version: '2.1', license: 'LGPL', meson_version : '>=0.53.2', default_options : [
-	'c_std=gnu11',
-	'optimization=s',
 	'warning_level=2',
 	'werror=true'])
 

--- a/meson.build
+++ b/meson.build
@@ -67,18 +67,12 @@ csp_c_args = ['-Wshadow',
 subdir('src')
 subdir('include/csp')
 
-if not meson.is_subproject()
-  install_subdir('include', install_dir : '.')
-  install_headers(csp_config_h, install_dir : 'include/csp')
-endif
-
-
 csp_lib = library('csp',
 	sources: [csp_sources, csp_config_h],
 	include_directories : csp_inc,
 	dependencies : csp_deps,
 	c_args : csp_c_args,
-	install : false,
+	install : true,
 	pic:true,
 )
 
@@ -89,6 +83,10 @@ csp_dep = declare_dependency(
 	link_with : csp_lib,
 	dependencies : csp_deps,
 )
+
+install_subdir('include', install_dir : '.', exclude_files: ['csp/meson.build'])
+pkg = import('pkgconfig')
+pkg.generate(csp_lib)
 
 subdir('examples')
 

--- a/meson.build
+++ b/meson.build
@@ -83,8 +83,7 @@ csp_dep = declare_dependency(
 	link_with : csp_lib,
 	dependencies : csp_deps,
 )
-
-install_subdir('include', install_dir : '.', exclude_files: ['csp/meson.build'])
+install_subdir('include', install_dir : '.', exclude_files: ['csp/meson.build'], install_tag: 'devel')
 pkg = import('pkgconfig')
 pkg.generate(csp_lib)
 

--- a/meson.build
+++ b/meson.build
@@ -74,6 +74,7 @@ csp_lib = library('csp',
 	c_args : csp_c_args,
 	install : true,
 	pic:true,
+	soversion: meson.project_version()
 )
 
 # The following dependency variable is for parent projects to link

--- a/src/csp_buffer.c
+++ b/src/csp_buffer.c
@@ -139,7 +139,7 @@ void * csp_buffer_clone(void * buffer) {
 
 	csp_packet_t * clone = csp_buffer_get(packet->length);
 	if (clone) {
-		size_t size = sizeof(csp_packet_t) - CSP_BUFFER_SIZE + CSP_PACKET_PADDING_BYTES + packet->length;
+		size_t size = sizeof(csp_packet_t) - CSP_BUFFER_SIZE + packet->length;
 		memcpy(clone, packet, size > sizeof(csp_packet_t) ? sizeof(csp_packet_t) : size);
 	}
 

--- a/src/csp_buffer.c
+++ b/src/csp_buffer.c
@@ -45,8 +45,8 @@ static csp_packet_t * csp_buffer_get_actual(int reserve, int isr) {
 	} else {
 		remain = csp_queue_size(csp_buffers);
 	}
-	/* Respect if remaining is lower than the reserve requested */
-	if (remain < reserve) {
+	/* Respect the requested reserve */
+	if (remain <= reserve) {
 		return NULL;
 	}
 

--- a/src/csp_buffer.c
+++ b/src/csp_buffer.c
@@ -141,6 +141,7 @@ void * csp_buffer_clone(void * buffer) {
 	if (clone) {
 		size_t size = sizeof(csp_packet_t) - CSP_BUFFER_SIZE + packet->length;
 		memcpy(clone, packet, size > sizeof(csp_packet_t) ? sizeof(csp_packet_t) : size);
+		clone->frame_begin = (clone->header + CSP_PACKET_PADDING_BYTES) - (packet->data - packet->frame_begin);
 	}
 
 	return clone;

--- a/src/csp_conn.c
+++ b/src/csp_conn.c
@@ -252,13 +252,13 @@ csp_conn_t * csp_connect(uint8_t prio, uint16_t dest, uint8_t dport, uint32_t ti
 	opts |= csp_conf.conn_dfl_so;
 	
 	/* Generate identifier */
-	csp_id_t incoming_id, outgoing_id;
+	csp_id_t incoming_id = {0}, outgoing_id = {0};
 
 	/* Use 0 as incoming id (this disables the input filter on destination node)
 	 * This means that for this outgoing connection, we accept the answer coming to whatever address
 	 * the outgoing interface has. CSP does not support "source address" on outgoing connections 
 	 * so the outgoing source address will be automatically applied after outgoing routing 
-	 * selects which interface the packet will leavve from */
+	 * selects which interface the packet will leave from */
 	incoming_id.dst = 0; 
 	outgoing_id.src = 0; 
 

--- a/src/csp_iflist.c
+++ b/src/csp_iflist.c
@@ -133,6 +133,18 @@ csp_iface_t * csp_iflist_get_by_addr(uint16_t addr) {
 
 }
 
+csp_iface_t * csp_iflist_get_by_broadcast(uint16_t addr) {
+
+	csp_iface_t * ifc = interfaces;
+	while (ifc) {
+		if (csp_id_is_broadcast(addr, ifc)) {
+			return ifc;
+		}
+		ifc = ifc->next;
+	}
+	return NULL;
+}
+
 csp_iface_t * csp_iflist_get_by_name(const char * name) {
 	csp_iface_t * ifc = interfaces;
 	while (ifc) {

--- a/src/csp_rdp.c
+++ b/src/csp_rdp.c
@@ -409,6 +409,12 @@ void csp_rdp_check_timeouts(csp_conn_t * conn) {
 
 	if (conn->rdp.state == RDP_OPEN) {
 
+		if (csp_rdp_time_after(time_now, conn->timestamp + conn->rdp.conn_timeout)) {
+			csp_conn_close(conn, CSP_RDP_CLOSED_BY_PROTOCOL | CSP_RDP_CLOSED_BY_TIMEOUT);
+			csp_bin_sem_post(&conn->rdp.tx_wait);
+			return;
+		}
+
 		/* Check if we have unacknowledged segments */
 		if (conn->rdp.delayed_acks) {
 			csp_rdp_check_ack(conn);

--- a/src/csp_route.c
+++ b/src/csp_route.c
@@ -136,7 +136,9 @@ int csp_route_work(void) {
 
 	/* The packet is to me, if the address matches that of any interface,
 	 * or the address matches the broadcast address of the incoming interface */
-	int is_to_me = (csp_iflist_get_by_addr(packet->id.dst) != NULL || (csp_id_is_broadcast(packet->id.dst, input.iface)));
+	int is_to_me = ((csp_iflist_get_by_addr(packet->id.dst) != NULL ||
+	                (csp_id_is_broadcast(packet->id.dst, input.iface))) ||
+				    (csp_addr_is_alias(packet->id.dst)));
 
 	/* Deduplication */
 	if ((csp_conf.dedup == CSP_DEDUP_ALL) ||

--- a/src/csp_rtable_cidr.c
+++ b/src/csp_rtable_cidr.c
@@ -81,8 +81,8 @@ int csp_rtable_set_internal(uint16_t address, uint16_t netmask, csp_iface_t * if
 	/* If not, create a new one */
 	if (!entry) {
 		entry = &rtable[rtable_inptr++];
-		if (rtable_inptr > CSP_RTABLE_SIZE) {
-			rtable_inptr = CSP_RTABLE_SIZE;
+		if (rtable_inptr >= CSP_RTABLE_SIZE) {
+			rtable_inptr = CSP_RTABLE_SIZE-1;
 		}
 	}
 

--- a/src/csp_rtable_stdio.c
+++ b/src/csp_rtable_stdio.c
@@ -24,13 +24,13 @@ static int csp_rtable_parse(const char * rtable, int dry_run) {
 	while ((str) && (strlen(str) > 1)) {
 		unsigned int address, via;
 		int netmask;
-		char name[15];
-		if (sscanf(str, "%u/%d %14s %u", &address, &netmask, name, &via) == 4) {
-		} else if (sscanf(str, "%u/%d %14s", &address, &netmask, name) == 3) {
+		char name[CSP_IFLIST_NAME_MAX] = {0};
+		if (sscanf(str, "%u/%d %9s %u", &address, &netmask, name, &via) == 4) {
+		} else if (sscanf(str, "%u/%d %9s", &address, &netmask, name) == 3) {
 			via = CSP_NO_VIA_ADDRESS;
-		} else if (sscanf(str, "%u %14s %u", &address, name, &via) == 3) {
+		} else if (sscanf(str, "%u %9s %u", &address, name, &via) == 3) {
 			netmask = csp_id_get_host_bits();
-		} else if (sscanf(str, "%u %14s", &address, name) == 2) {
+		} else if (sscanf(str, "%u %9s", &address, name) == 2) {
 			netmask = csp_id_get_host_bits();
 			via = CSP_NO_VIA_ADDRESS;
 		} else {

--- a/src/csp_service_handler.c
+++ b/src/csp_service_handler.c
@@ -143,7 +143,7 @@ static int do_cmp_poke(struct csp_cmp_message * cmp) {
 static int do_cmp_peek_v2(struct csp_cmp_message * cmp) {
 
 	cmp->peek_v2.vaddr = htobe64(cmp->peek_v2.vaddr);
-	if (cmp->peek_v2.len > CSP_CMP_PEEK_MAX_LEN)
+	if (cmp->peek_v2.len > CSP_CMP_PEEK_V2_MAX_LEN)
 		return CSP_ERR_INVAL;
 
 	if (!csp_cmp_memread64_fnc) {
@@ -159,7 +159,7 @@ static int do_cmp_peek_v2(struct csp_cmp_message * cmp) {
 static int do_cmp_poke_v2(struct csp_cmp_message * cmp) {
 
 	cmp->poke_v2.vaddr = htobe64(cmp->poke_v2.vaddr);
-	if (cmp->poke_v2.len > CSP_CMP_POKE_MAX_LEN)
+	if (cmp->poke_v2.len > CSP_CMP_POKE_V2_MAX_LEN)
 		return CSP_ERR_INVAL;
 
 	if (!csp_cmp_memwrite64_fnc) {

--- a/src/csp_service_handler.c
+++ b/src/csp_service_handler.c
@@ -22,10 +22,20 @@ static uint32_t wrap_32bit_memcpy(uint32_t to, const uint32_t from, size_t size)
 static csp_memcpy_fnc_t csp_cmp_memcpy_fnc = wrap_32bit_memcpy;
 #else
 static csp_memcpy_fnc_t csp_cmp_memcpy_fnc = (csp_memcpy_fnc_t)memcpy;
+static csp_memread64_fnc_t csp_cmp_memread64_fnc = (csp_memread64_fnc_t)NULL;
+static csp_memwrite64_fnc_t csp_cmp_memwrite64_fnc = (csp_memwrite64_fnc_t)NULL;
 #endif
 
 void csp_cmp_set_memcpy(csp_memcpy_fnc_t fnc) {
 	csp_cmp_memcpy_fnc = fnc;
+}
+
+void csp_cmp_set_memread64(csp_memread64_fnc_t fnc) {
+	csp_cmp_memread64_fnc = fnc;
+}
+
+void csp_cmp_set_memwrite64(csp_memwrite64_fnc_t fnc) {
+	csp_cmp_memwrite64_fnc = fnc;
 }
 
 static int do_cmp_ident(struct csp_cmp_message * cmp) {
@@ -130,6 +140,38 @@ static int do_cmp_poke(struct csp_cmp_message * cmp) {
 	return CSP_ERR_NONE;
 }
 
+static int do_cmp_peek_v2(struct csp_cmp_message * cmp) {
+
+	cmp->peek_v2.vaddr = htobe64(cmp->peek_v2.vaddr);
+	if (cmp->peek_v2.len > CSP_CMP_PEEK_MAX_LEN)
+		return CSP_ERR_INVAL;
+
+	if (!csp_cmp_memread64_fnc) {
+		return CSP_ERR_DRIVER;
+	}
+
+	/* Dangerous, you better know what you are doing */
+	csp_cmp_memread64_fnc(cmp->peek_v2.data, cmp->peek_v2.vaddr, cmp->peek_v2.len);
+
+	return CSP_ERR_NONE;
+}
+
+static int do_cmp_poke_v2(struct csp_cmp_message * cmp) {
+
+	cmp->poke_v2.vaddr = htobe64(cmp->poke_v2.vaddr);
+	if (cmp->poke_v2.len > CSP_CMP_POKE_MAX_LEN)
+		return CSP_ERR_INVAL;
+
+	if (!csp_cmp_memwrite64_fnc) {
+		return CSP_ERR_DRIVER;
+	}
+
+	/* Extremely dangerous, you better know what you are doing */
+	csp_cmp_memwrite64_fnc(cmp->poke_v2.vaddr, cmp->poke_v2.data, cmp->poke_v2.len);
+
+	return CSP_ERR_NONE;
+}
+
 static int do_cmp_clock(struct csp_cmp_message * cmp) {
 
 	csp_timestamp_t clock;
@@ -190,6 +232,14 @@ static int csp_cmp_handler(csp_packet_t * packet) {
 
 		case CSP_CMP_POKE:
 			ret = do_cmp_poke(cmp);
+			break;
+
+		case CSP_CMP_PEEK_V2:
+			ret = do_cmp_peek_v2(cmp);
+			break;
+
+		case CSP_CMP_POKE_V2:
+			ret = do_cmp_poke_v2(cmp);
 			break;
 
 		case CSP_CMP_CLOCK:

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -46,8 +46,9 @@ static void * socketcan_rx_thread(void * arg) {
 		fd_set input;
 		FD_ZERO(&input);
 		FD_SET(ctx->socket, &input);
-		struct timeval timeout;
-		timeout.tv_sec = 10;
+		struct timeval timeout = {
+			.tv_sec = 10,
+		};
 		int n = select(ctx->socket + 1, &input, NULL, NULL, &timeout);
 		if (n == -1) {
 			csp_print("CAN read error\n");

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -368,7 +368,7 @@ int csp_can2_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t 
 int csp_can2_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet, int from_me) {
 
 	/* Loopback */
-	if (packet->id.dst == iface->addr) {
+	if (packet->id.dst == iface->addr || csp_addr_is_alias(packet->id.dst)) {
 		csp_qfifo_write(packet, iface, NULL);
 		return CSP_ERR_NONE;
 	}

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -245,6 +245,20 @@ void csp_zmqhub_remove_filters(csp_iface_t * zmq_iface) {
 	(void)ret;
 }
 
+int csp_zmqhub_add_filter(void * driver_data, uint16_t addr) {
+
+	int ret = 0;
+	zmq_driver_t * drv = (zmq_driver_t*)driver_data;
+
+	/* Subscribe to an extra address, typically registered by alias address */
+	for (int i = 0; i < 4; i++) {
+		uint16_t filter = __builtin_bswap16((i << 14) | addr);
+		ret = zmq_setsockopt(drv->subscriber, ZMQ_SUBSCRIBE, &filter, 2);
+		assert(ret == 0);
+	}
+	return ret;
+}
+
 void csp_zmqhub_add_filters(csp_iface_t * zmq_iface) {
 
 	int ret = 0;
@@ -300,6 +314,7 @@ int csp_zmqhub_init_filter2(const char * ifname, const char * host, uint16_t add
 	drv->iface.name = drv->name;
 	drv->iface.driver_data = drv;
 	drv->iface.nexthop = csp_zmqhub_tx;
+	drv->iface.add_alias = csp_zmqhub_add_filter;
 
 	drv->iface.addr = addr;
 	drv->iface.netmask = netmask;

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -207,7 +207,7 @@ int csp_zmqhub_init_w_name_endpoints_rxfilter(const char * ifname, uint16_t addr
 	assert(ret == 0);
 	ret = pthread_create(&drv->rx_thread, &attributes, csp_zmqhub_task, drv);
 	assert(ret == 0);
-
+	(void)ret;
 	/* Register interface */
 	csp_iflist_add(&drv->iface);
 
@@ -293,7 +293,7 @@ int csp_zmqhub_init_filter2(const char * ifname, const char * host, uint16_t add
 	assert(ret == 0);
 	ret = zmq_connect(drv->subscriber, sub);
 	assert(ret == 0);
-
+	(void)ret;
 
 	if (promisc) {
 

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -252,7 +252,7 @@ void csp_zmqhub_add_filters(csp_iface_t * zmq_iface) {
 	const uint16_t addr = zmq_iface->addr;
 	const uint16_t hostmask = (1 << (csp_id_get_host_bits() - zmq_iface->netmask)) - 1;
 
-	/* Subscribe to all packets - no filter */
+	/* Unsubscribe to all packets */
 	ret = zmq_setsockopt(drv->subscriber, ZMQ_UNSUBSCRIBE, NULL, 0);
 	assert(ret == 0);
 

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -291,7 +291,7 @@ int csp_zmqhub_init_filter2(const char * ifname, const char * host, uint16_t add
 	const ssize_t sec_key_len = sec_key ? strnlen(sec_key, CURVE_KEYLEN-1) : 0;
 	if (sec_key_len && sec_key_len != CURVE_KEYLEN-1) {
 		/* Is it bad to expose the detected length of the ZMQ key here? */
-		fprintf(stderr, "ZMQ secret key must be exactly 40 characters long (got %ld)\n", sec_key_len);
+		fprintf(stderr, "ZMQ secret key must be exactly 40 characters long (got %ld)\n", (signed long)sec_key_len);
 		return CSP_ERR_INVAL;
 	}
 


### PR DESCRIPTION
Currently, installing CSP through meson does not allow other modules to use the installed version as it does not generate the required pkg-config files, this PR addresses this