### PR TITLE
Use atomic_int for cfp_packet_counter in CAN and packet_id in ETH TX

### DIFF
--- a/include/csp/interfaces/csp_if_can.h
+++ b/include/csp/interfaces/csp_if_can.h
@@ -60,6 +60,8 @@
 #pragma once
 
 #include <csp/csp_interface.h>
+#include <stdint.h>
+#include <stdatomic.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -190,7 +192,7 @@ typedef int (*csp_can_driver_tx_t)(void * driver_data, uint32_t id, const uint8_
  * Interface data (state information).
  */
 typedef struct {
-	uint32_t cfp_packet_counter; /**< CFP Identification number - same number on all fragments from same CSP packet. */
+	atomic_int cfp_packet_counter; /**< CFP Identification number - same number on all fragments from same CSP packet. */
 	csp_can_driver_tx_t tx_func; /**< Tx function */
 	csp_packet_t * pbufs; /**< PBUF queue */
 } csp_can_interface_data_t;

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -166,8 +166,8 @@ static int csp_can1_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet,
 
 	csp_can_interface_data_t * ifdata = iface->interface_data;
 
-	/* Get an unique CFP id - this should be locked to prevent access from multiple tasks */
-	const uint32_t ident = ifdata->cfp_packet_counter++;
+	/* Get an unique CFP id */
+	const uint32_t ident = ifdata->cfp_packet_counter++; // Atomic operation as cfp_packet_counter is of type atomic_int
 
 	/* Figure out destination node based on routing entry */
 	const uint8_t dest = (via != CSP_NO_VIA_ADDRESS) ? via : packet->id.dst;
@@ -370,7 +370,7 @@ static int csp_can2_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet,
 	csp_can_interface_data_t * ifdata = iface->interface_data;
 
 	/* Setup counters */
-	int sender_count = ifdata->cfp_packet_counter++;
+	int sender_count = ifdata->cfp_packet_counter++; // Atomic operation as cfp_packet_counter is of type atomic_int
 	int tx_count = 0;
 
 	uint32_t can_id = 0;

--- a/src/interfaces/csp_if_eth.c
+++ b/src/interfaces/csp_if_eth.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <stdatomic.h>
 
 #include <csp/csp.h>
 #include <csp/csp_id.h>
@@ -254,7 +255,7 @@ int csp_eth_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet, int fro
 
     csp_id_prepend(packet);
 
-    static uint16_t packet_id = 0;
+    static atomic_int packet_id = 0;
     packet_id++;
     uint16_t offset = 0;
 


### PR DESCRIPTION
This is needed as ++ is not atomic on an integer